### PR TITLE
Unmap f, F, <a-f> on phantom-disable

### DIFF
--- a/rc/phantom.kak
+++ b/rc/phantom.kak
@@ -56,8 +56,6 @@ provide-module phantom %{
   define-command phantom-disable -docstring 'Disable phantom' %{
     remove-highlighter global/phantom
     remove-hooks global phantom
-    unmap global normal Z
-    unmap global normal z
     unmap global insert <a-i>
     unmap global insert <a-a>
     unmap global insert <a-n>

--- a/rc/phantom.kak
+++ b/rc/phantom.kak
@@ -60,6 +60,9 @@ provide-module phantom %{
     unmap global insert <a-a>
     unmap global insert <a-n>
     unmap global insert <a-p>
+    unmap global normal F
+    unmap global normal f
+    unmap global normal <a-f>
   }
 
   define-command phantom-save -docstring 'Save phantom selections' %{


### PR DESCRIPTION
I think `phantom-disable` should restore ` f, F, <a-f>` to their default behavior.